### PR TITLE
[issue-4] Fixed #4, removed unused stuff from arduino binaries

### DIFF
--- a/modules/template-arduino/CMakeLists.txt
+++ b/modules/template-arduino/CMakeLists.txt
@@ -1,28 +1,33 @@
 cmake_minimum_required (VERSION 2.8.11)
 set(toolchain ../../toolchain) # Your path to kvasir_toolchain
 set(CMAKE_TOOLCHAIN_FILE ${toolchain}/compilers/arm-none-eabi.cmake)
-project (template-arduino CXX)
+project(template-arduino CXX)
 
-set(hwlib ../../libraries/hwlib)
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -specs=nosys.specs")
 include(../../flags.cmake)
 
-add_definitions(-DBMPTK_TARGET_arduino_due)
+set(cxxflags
+    "-Os"
+    "-ffunction-sections"
+    "-fdata-sections"
+    "-fno-exceptions"
+    "-fno-rtti"
+    "-fno-threadsafe-statics")
 
-include_directories(
-	${hwlib}/library
-)
+string(REGEX REPLACE ";" " " cxxflags "${cxxflags}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${cxxflags}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -nostartfiles -nostdlib")
+
+link_libraries(gcc)
+
+set(hwlib ../../libraries/hwlib)
+add_definitions(-DBMPTK_TARGET_arduino_due)
+include_directories(${hwlib}/library)
 
 set(sources
     src/wrap-hwlib.cc
+    src/libc-stub.cc
     src/main.cc
 )
-
-# Location of the flash tool if it's not in your path
-#set(flash_program_path ~/bossac) # Your path to the flash tool
-
-# The compiler that is used:
-#include(${toolchain}/compilers/arm-none-eabi.cmake)
 
 # The target chip that is compiled for:
 include(${toolchain}/targets/arm32/cm3/atmel/sam3x/sam3x8e/sam3x8e.cmake)

--- a/modules/template-arduino/src/libc-stub.cc
+++ b/modules/template-arduino/src/libc-stub.cc
@@ -1,0 +1,3 @@
+// Pretend that we have a cstdlib to please kvasir-toolchain.
+extern "C" void __libc_init_array();
+extern "C" void __libc_init_array() { }


### PR DESCRIPTION
This allows `-gc-sections` to remove all unused hwlib code and data (see similar https://github.com/wovo/hwlib/issues/1 ).
Additionally we remove stdlib stuff and libc startup code, shaving another ~1K off the binary. I've put this configuration in the template CMakeLists.txt, so module authors that need the stdlib for whatever reason can re-enable it if they wish.