### PR TITLE
Issue 5, hwlib issues

### DIFF
--- a/modules/template-arduino/CMakeLists.txt
+++ b/modules/template-arduino/CMakeLists.txt
@@ -20,8 +20,10 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -nostartfiles -nostdlib")
 link_libraries(gcc)
 
 set(hwlib ../../libraries/hwlib)
-add_definitions(-DBMPTK_TARGET_arduino_due)
 include_directories(${hwlib}/library)
+add_definitions(-DBMPTK_TARGET_arduino_due
+                -DBMPTK_TARGET=arduino_due
+                -DBMPTK_BAUDRATE=19200)
 
 set(sources
     src/wrap-hwlib.cc


### PR DESCRIPTION
This fixes #5 .
- hwlib update fixes LED pin.
- baudrate downgrade fixes console issues. (we didn't pass a baud rate at all which completely disabled serial I/O, but additionally the rate of 38400 from previous hwlib projects doesn't work anymore, probably due to hwlib timing issues).